### PR TITLE
New zgoubi compat

### DIFF
--- a/devtools/make_outputs.py
+++ b/devtools/make_outputs.py
@@ -1,6 +1,11 @@
+#!/usr/bin/env python2
 
 # makes zgoubi output files fai and plt in ascii and binary
 # note that for plt files, the ascii/binary choise must be made at compile time by modifying include/FILPLT.H
+
+binname = os.path.basename(zgoubi_settings['zgoubi_path'])
+outdir = "result_"+binname
+mkdir_p(outdir)
 
 for binary in [True, False]:
 	make_line('line')
@@ -34,21 +39,21 @@ for binary in [True, False]:
 	
 	if binary:
 		try:
-			res.save_b_fai("binary.fai")
+			res.save_b_fai(os.path.join(outdir,"binary.fai"))
 		except IOError:
 			print "could not save binary.fai"
 		try:
-			res.save_b_plt("binary.plt")
+			res.save_b_plt(os.path.join(outdir,"binary.plt"))
 		except IOError:
 			print "could not save binary.plt"
 	else:
-		res.save_fai("ascii.fai")
+		res.save_fai(os.path.join(outdir,"ascii.fai"))
 		try:
 			res.save_fai("ascii.fai")
 		except IOError:
 			print "could not save ascii.fai"
 		try:
-			res.save_plt("ascii.plt")
+			res.save_plt(os.path.join(outdir,"ascii.plt"))
 		except IOError:
 			print "could not save ascii.plt"
 

--- a/devtools/read_outputs.py
+++ b/devtools/read_outputs.py
@@ -3,36 +3,17 @@
 
 from zgoubi import io
 
-io.store_def_all() ; exit()
+#io.store_def_all()
 
-af =  io.read_file("ascii.fai")
-#print af
-print af.shape
-print af[0]
-
-bf =  io.read_file("binary.fai")
-#print bf
-print bf.shape
-print bf[0]
-
-#for n, p in zip( af[0], bf[0]): print p
-
-
-
-print "plt"
-
-af =  io.read_file("ascii.plt")
-#print af
-print af.shape
-print af[0]
-
-bf =  io.read_file("binary.plt")
-#print bf
-print bf.shape
-print bf[0]
-
-#for p in zip( af[0], bf[0]): print p
-
+for fname in ["ascii.fai", "ascii.plt", "binary.fai", "binary.plt"]:
+	print "Reading", fname
+	try:
+		af = io.read_file(fname)
+		#print af
+		print af.shape
+		print af[0]
+	except IOError:
+		print "IOError reading", fname
 
 
 

--- a/tests/20-inout_YTZP_ascii_plt.py
+++ b/tests/20-inout_YTZP_ascii_plt.py
@@ -40,13 +40,13 @@ res = run(xterm=False)
 if binary:
 	plt_data =  res.get_track('bplt', ['Y','T','Z','P'])
 else:
-	plt_data =  numpy.array(res.get_track('plt', ['Y','T','Z','P'])) / [100, 1000, 100, 1000]
-
+	plt_data =  numpy.array(res.get_track('plt', ['Y','T','Z','P','S'])) / [100, 1000, 100, 1000, 1]
 
 
 
 #select the points from entrance of the magnet
-plt_data = plt_data[::3]
+plt_data = plt_data[plt_data[:,4] == 0]
+plt_data = plt_data[:,0:4]
 
 #print
 #print b_orig_4d


### PR DESCRIPTION
Allow pyzgoubi to read files with current pygzgoubi dev version.

This works for zgoubi r1331 with the changes to open2.f and obj3.f from r1353. Not yet tested on latest revisions because of issues with zgoubi's makefiles. 